### PR TITLE
Add custom HTML option for ads

### DIFF
--- a/assets/javascripts/discourse/templates/connectors/discovery-list-container-top/adsense.hbs
+++ b/assets/javascripts/discourse/templates/connectors/discovery-list-container-top/adsense.hbs
@@ -1,5 +1,13 @@
 {{#if site.mobileView}}
-  {{adsenseBlock "320" "50" "topiclist_top_mobile"}}
+  {{#if siteSettings.custom_html_discovery_list_container_top_mobile}}
+    {{{siteSettings.custom_html_discovery_list_container_top_mobile }}}
+  {{else}}
+    {{adsenseBlock "320" "50" "topiclist_top_mobile"}}
+  {{/if}}
 {{else}}
-  {{adsenseBlock "728" "90" "topiclist_top"}}
+  {{#if siteSettings.custom_html_discovery_list_container_top}}
+    {{{siteSettings.custom_html_discovery_list_container_top}}}
+  {{else}}
+    {{adsenseBlock "728" "90" "topiclist_top"}}
+  {{/if}}
 {{/if}}

--- a/assets/javascripts/discourse/templates/connectors/post-bottom/adsense.hbs
+++ b/assets/javascripts/discourse/templates/connectors/post-bottom/adsense.hbs
@@ -1,5 +1,13 @@
 {{#if site.mobileView}}
-  {{adsenseBlock "320" "50" "post-bottom" postNumber=post_number}}
+  {{#if siteSettings.custom_html_post_bottom_mobile}}
+    {{{siteSettings.custom_html_post_bottom_mobile }}}
+  {{else}}
+    {{adsenseBlock "320" "50" "post-bottom" postNumber=post_number}}
+  {{/if}}
 {{else}}
-  {{adsenseBlock "728" "90" "post-bottom" postNumber=post_number}}
+  {{#if siteSettings.custom_html_post_bottom}}
+    {{{siteSettings.custom_html_post_bottom}}}
+  {{else}}
+    {{adsenseBlock "728" "90" "post-bottom" postNumber=post_number}}
+  {{/if}}
 {{/if}}

--- a/assets/javascripts/discourse/templates/connectors/topic-above-post-stream/adsense.hbs
+++ b/assets/javascripts/discourse/templates/connectors/topic-above-post-stream/adsense.hbs
@@ -1,5 +1,13 @@
 {{#if site.mobileView}}
-  {{adsenseBlock "320" "50" "topic_top_mobile"}}
+  {{#if siteSettings.custom_html_topic_above_post_stream_mobile}}
+    {{{siteSettings.custom_html_topic_above_post_stream_mobile}}}
+  {{else}}
+    {{adsenseBlock "320" "50" "topic_top_mobile"}}
+  {{/if}}
 {{else}}
-  {{adsenseBlock "728" "90" "topic_top"}}
+  {{#if siteSettings.custom_html_topic_above_post_stream}}
+    {{{siteSettings.custom_html_topic_above_post_stream}}}
+  {{else}}
+    {{adsenseBlock "728" "90" "topic_top"}}
+  {{/if}}
 {{/if}}

--- a/assets/javascripts/discourse/templates/connectors/topic-above-suggested/adsense.hbs
+++ b/assets/javascripts/discourse/templates/connectors/topic-above-suggested/adsense.hbs
@@ -1,5 +1,13 @@
 {{#if site.mobileView}}
-  {{adsenseBlock "320" "50" "topic_bottom_mobile"}}
+  {{#if siteSettings.custom_html_topic_above_suggested_mobile}}
+    {{{siteSettings.custom_html_topic_above_suggested_mobile}}}
+  {{else}}
+    {{adsenseBlock "320" "50" "topic_bottom_mobile"}}
+  {{/if}}
 {{else}}
-  {{adsenseBlock "728" "90" "topic_bottom"}}
+  {{#if siteSettings.custom_html_topic_above_suggested}}
+    {{{siteSettings.custom_html_topic_above_suggested}}}
+  {{else}}
+    {{adsenseBlock "728" "90" "topic_bottom"}}
+  {{/if}}
 {{/if}}

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -16,4 +16,12 @@ en:
     adsense_nth_post_code: "Show an ad after every N posts, where N is this value."
     adsense_through_trust_level: 'Show ads to users through trust level (0 = to not logged in users only ... 4 = to all users)'
     adsense_through_badge: 'Hides ads to users with this badge. '
+    custom_html_discovery_list_container_top: 'Add custom HTML to display instead of the ad in top discovery list container'
+    custom_html_post_bottom: 'Add custom HTML to display instead of the ad in bottom of a post'
+    custom_html_topic_above_post_stream: 'Add custom HTML to display instead of the ad above the post stream'
+    custom_html_topic_above_suggested: 'Add custom HTML to display instead of the ad above suggested'
+    custom_html_discovery_list_container_top_mobile: 'Add custom HTML to display instead of the ad in mobile view of top discovery list container'
+    custom_html_post_bottom_mobile: 'Add custom HTML to display instead of the ad in mobile view in bottom of a post'
+    custom_html_topic_above_post_stream_mobile: 'Add custom HTML to display instead of the ad in the mobile view above the post stream'
+    custom_html_topic_above_suggested_mobile: 'Add custom HTML to display instead of the ad in mobile view above suggested'
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -50,3 +50,27 @@ adsense_plugin:
     client: true
     default: ''
     type: list
+  custom_html_discovery_list_container_top:
+    client: true
+    default: ''
+  custom_html_discovery_list_container_top_mobile:
+    client: true
+    default: ''
+  custom_html_post_bottom:
+    client: true
+    default: ''
+  custom_html_post_bottom_mobile:
+    client: true
+    default: ''
+  custom_html_topic_above_post_stream:
+    client: true
+    default: ''
+  custom_html_topic_above_post_stream_mobile:
+    client: true
+    default: ''
+  custom_html_topic_above_suggested:
+    client: true
+    default: ''
+  custom_html_topic_above_suggested_mobile:
+    client: true
+    default: ''


### PR DESCRIPTION
This code adds the option to display custom HTML instead of the ads
being pulled in from Adsense. Custom HTML is boxes for each of the four
ad slots can be edited in the settings. It is currently just a text field
but we may want to edit it eventually to be a custom template for the settings 
that is a textfield instead but this works and was a quick solution.

The custom HTML that is typed inside the box is then rendered in the template
instead of the ad if it isn't empty. There are custom HTML boxes for both
the mobile and desktop views.
